### PR TITLE
Some stylistic changes and error in WaitGroup usage

### DIFF
--- a/ctlcmds.go
+++ b/ctlcmds.go
@@ -84,14 +84,15 @@ func (c *ctlCmdHelp) Names() []string {
 func (c *ctlCmdHelp) Run(ctl *ctl, params []string) bool {
 	if len(params) == 1 {
 		for _, cmd := range cmdAll() {
-			if match, ok := cmd.(cmdMatcher); ok {
-				for _, name := range cmd.Names() {
-					match.Match(name)
-					ctl.println(cmd.Help())
-				}
+			match, ok := cmd.(cmdMatcher)
+			if !ok {
+				ctl.println(cmd.Help())
 				continue
 			}
-			ctl.println(cmd.Help())
+			for _, name := range cmd.Names() {
+				match.Match(name)
+				ctl.println(cmd.Help())
+			}
 		}
 		return false
 	}

--- a/svctl.go
+++ b/svctl.go
@@ -358,8 +358,8 @@ func (c *ctl) Ctl(cmdStr string) bool {
 			c.printf("%s: unable to find service\n", param)
 			continue
 		}
+		wg.Add(len(services))
 		for _, service := range services {
-			wg.Add(1)
 			go c.ctl(action, service, start, &wg)
 		}
 	}

--- a/svctl.go
+++ b/svctl.go
@@ -182,6 +182,7 @@ func (c *ctl) Close() {
 		log.Printf("error writing history file: %s, lines written: %d\n", err, n)
 	}
 	c.line.Close()
+	f.Close()
 }
 
 func (c *ctl) completer(line string, pos int) (h string, compl []string, t string) {

--- a/svctl.go
+++ b/svctl.go
@@ -173,12 +173,13 @@ func newCtl(stdout io.Writer) *ctl {
 // Close Closes input prompt, saves history to file.
 func (c *ctl) Close() {
 	fn, _ := xdg.DataFile("svctl/hist")
-	if f, err := os.Create(fn); err == nil {
-		if n, err := c.line.WriteHistory(f); err != nil {
-			log.Printf("error writing history file: %s, lines written: %d\n", err, n)
-		}
-	} else {
+	f, err := os.Create(fn)
+	if err != nil {
 		log.Printf("error opening history file: %s\n", err)
+		return
+	}
+	if n, err := c.line.WriteHistory(f); err != nil {
+		log.Printf("error writing history file: %s, lines written: %d\n", err, n)
 	}
 	c.line.Close()
 }


### PR DESCRIPTION
Hi Kenji, nice job!

I have made a few stylistic changes to keep the style of "returning early" on error.

I also changed two other things:
1. How the WorkGroup is used (it's safer to increment it at once, in case one of the go routines calls Done too early);
2. So that the history file is closed (and flushed) on exit.

Let me know if the tests run correctly for you, sadly I don't have ruinit on this machine.
